### PR TITLE
Exit if a sessionID wasn't provided

### DIFF
--- a/killstream/kill_stream.py
+++ b/killstream/kill_stream.py
@@ -264,6 +264,10 @@ if __name__ == "__main__":
 
     opts = parser.parse_args()
 
+    if not opts.sessionId:
+        sys.stderr.write("No sessionId provided! Is this synced content?\n")
+        sys.exit(1)
+
     if opts.killMessage:
         message = ' '.join(opts.killMessage)
     else:


### PR DESCRIPTION
If the user mistakenly calls the script without a `sessionID`, exit early with a warning message and the likely reason.
