### PR TITLE
Add synced content check to wait paused example

### DIFF
--- a/killstream/readme.md
+++ b/killstream/readme.md
@@ -20,7 +20,9 @@ _The default values will kill anything paused for over 20 minutes, checking ever
 
 Script Timeout: 0 _**Important!**_  
 Triggers: Playback Paused  
-Conditions: \[ `Stream Local` | `is not` | `1` \]
+Conditions:
+* \[ `Stream Local` | `is not` | `1` \]
+* \[ `Synced Version` | `is not` | `1` \]
 
 Arguments:
 ```


### PR DESCRIPTION
Add a condition checking for synced content to the "waiting on paused streams" example, since synced content streams can't be terminated.

Let me know if you want this to be expanded to other examples @blacktwin. Unfortunately it would likely need to be on pretty much _all_ of them. #79 prevents it from causing issues if called without it though.
