### PR TITLE
Update limiterr.py duration as seconds

### DIFF
--- a/killstream/limiterr.py
+++ b/killstream/limiterr.py
@@ -294,6 +294,9 @@ if __name__ == "__main__":
             elif key == 'plays':
                 total_limit = int(value)
 
+    if opts.duration:
+        opts.duration = opts.duration * 60
+    
     if not opts.sessionId:
         sys.stderr.write("No sessionId provided! Is this synced content?\n")
         sys.exit(1)


### PR DESCRIPTION
Report the Duration value of an item in seconds instead of minutes for calculations.