### PR TITLE
Print raw response when JSON fails to parse

### DIFF
--- a/killstream/kill_stream.py
+++ b/killstream/kill_stream.py
@@ -268,7 +268,9 @@ class Tautulli:
         try:
             response_json = response.json()
         except ValueError:
-            print("Failed to parse json response for Tautulli API cmd '{}'".format(cmd))
+            print(
+                "Failed to parse json response for Tautulli API cmd '{}': {}"
+                .format(cmd, response.content))
             return
 
         if response_json['response']['result'] == 'success':


### PR DESCRIPTION
If the response to the Tautulli API fails to parse correctly include the raw output in the message to make it easier to diagnose when the response isn't actually raw JSON from a Tautulli server (e.g. a proxy server).