### PR TITLE
Update gmusic_playlists_to_plex.py

### DIFF
--- a/utility/gmusic_playlists_to_plex.py
+++ b/utility/gmusic_playlists_to_plex.py
@@ -75,7 +75,7 @@ def compare(ggmusic, pmusic):
     duration = int(ggmusic['durationMillis'])
 
     # Check if track numbers match
-    if int(pmusic.index) == int(tracknum):
+    if int(pmusic.index or 0) == int(tracknum):
         return [pmusic]
     # If not track number, check track title and album title
     elif title == pmusic.title and (album == pmusic.parentTitle or


### PR DESCRIPTION
Occasionally, plex music index returns NoneType and causes the script to error prematurely. We should add a default value to the int conversion to prevent this from happening with int(pmusic.index or 0).

Error:
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

Outcome:
By simply forcing 0 for the track number, int(pmusic.index) the comparison between Plex and GPM fails, leading the script to fall back to a track duration match or title match instead of erroring out.

I did not create an issue for this PR, as it is a simple fix, but feel free to ask me to make one for it.