### PR TITLE
Use the playlist.title, not the playlist object, for logging

### DIFF
--- a/fun/playlist_manager.py
+++ b/fun/playlist_manager.py
@@ -870,7 +870,7 @@ if __name__ == "__main__":
         logger.info("Displaying the user's playlist(s)...")
         for data in playlist_dict['data']:
             user = data['user']
-            playlists = [playlist for playlist in data['all_playlists']]
+            playlists = [playlist.title for playlist in data['all_playlists']]
             logger.info("{}'s current playlist(s): {}".format(user, ', '.join(playlists)))
         exit()
 


### PR DESCRIPTION
`python3 playlist_manager.py --action show --allUsers`

Displaying the user's playlist(s)...
Traceback (most recent call last):
  File "/Users/gene/repos/JBOPS/fun/playlist_manager.py", line 874, in <module>
    logger.info("{}'s current playlist(s): {}".format(user, ', '.join(playlists)))
TypeError: sequence item 0: expected str instance, Playlist found

This tiny commit fixes that.