### PR TITLE
Update to search for watched items

### DIFF
--- a/utility/sync_watch_status.py
+++ b/utility/sync_watch_status.py
@@ -501,7 +501,7 @@ if __name__ == '__main__':
                 # Check library for watched items
                 sectionFrom = watchedFrom.library.section(_library.title)
                 if _library.type == 'show':
-                    watched_lst = sectionFrom.search(libtype='episode', unwatched=False)
+                    watched_lst = sectionFrom.search(libtype='episode', **{'show.unwatchedLeaves': False})
                 else:
                     watched_lst = sectionFrom.search(unwatched=False)
 


### PR DESCRIPTION
PlexAPI updates caused issue found in #276. This update should resolve it. Requires PlexAPI > 4.2.0.