### PR TITLE
Update hide_episode_spoilers to work with entire show or season

### DIFF
--- a/utility/hide_episode_spoilers.py
+++ b/utility/hide_episode_spoilers.py
@@ -9,24 +9,25 @@
 #    * Notify on watched (optional - to remove the artwork after being watched)
 # Tautulli script conditions:
 #    * Condition {1}:
-#        [ Media Type | is | episode ]
+#        [Media Type | is | show or season or episode]
 #    * Condition {2} (optional):
 #        [ Library Name | is | DVR ]
 #        [ Show Namme | is | Game of Thrones ]
 # Tautulli script arguments:
 #    * Recently Added:
 #        To use an image file (can be image in the same directory as this script, or full path to an image):
-#            --rating_key {rating_key} --file {file} --image spoilers.png
+#            --rating_key {rating_key} --image spoilers.png
 #        To blur the episode artwork (optional blur in pixels):
-#            --rating_key {rating_key} --file {file} --blur 25
+#            --rating_key {rating_key} --blur 25
 #    * Watched (optional):
-#        --rating_key {rating_key} --file {file} --remove
+#        --rating_key {rating_key} --remove
 
 from __future__ import unicode_literals
 import argparse
 import os
 import requests
 import shutil
+import sys
 from plexapi.server import PlexServer
 
 TAUTULLI_URL = ''
@@ -63,49 +64,56 @@ def get_blurred_image(rating_key, blur=25):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--rating_key', required=True, type=int)
-    parser.add_argument('--file', required=True)
     parser.add_argument('--image')
     parser.add_argument('--blur', type=int, default=25)
     parser.add_argument('--remove', action='store_true')
     opts = parser.parse_args()
+
+    plex = PlexServer(PLEX_URL, PLEX_TOKEN)
+    item = plex.fetchItem(opts.rating_key)
     
-    if opts.remove:
-        # File path to episode artwork using the same episode file name without extension
-        episode_path = os.path.dirname(opts.file)
-        episode_filename = os.path.splitext(os.path.basename(opts.file))[0]
+    if item.type == 'show':
+        episodes = item.episodes()
+        show = item
+    elif item.type == 'season':
+        episodes = item.episodes()
+        show = item.show()
+    elif item.type == 'episode':
+        episodes = [item]
+        show = item.show()
+    else:
+        print('Only media type show, season, or episode is supported: '
+              '{item.title} ({item.ratingKey}) is media type {item.type}.'.format(item=item))
+        sys.exit(0)
 
-        # Find image files with the same name as the episode
-        for filename in os.listdir(episode_path):
-            if filename.startswith(episode_filename) and filename.endswith(('.jpg', '.png')):
-                # Delete the episode artwork image file
-                os.remove(os.path.join(episode_path, filename))
-
-        # Refresh metadata for the TV show
-        plex = PlexServer(PLEX_URL, PLEX_TOKEN)
-        plex.fetchItem(opts.rating_key).show().refresh()
-
-    elif opts.image:
-        # File path to episode artwork using the same episode file name
-        episode_artwork = os.path.splitext(opts.file)[0] + os.path.splitext(opts.image)[1]
-        
-        # Copy the image to the episode artwork
-        shutil.copy2(opts.image, episode_artwork)
-        
-        # Refresh metadata for the TV show
-        plex = PlexServer(PLEX_URL, PLEX_TOKEN)
-        plex.fetchItem(opts.rating_key).show().refresh()
-        
-    elif opts.blur:
-        # File path to episode artwork using the same episode file name
-        episode_artwork = os.path.splitext(opts.file)[0] + '.png'
-        
-        # Get the blurred artwork from Tautulli
-        blurred_artwork = get_blurred_image(opts.rating_key, opts.blur)
-        if blurred_artwork:
-            # Copy the image to the episode artwork
-            with open(episode_artwork, 'wb') as f:
-                shutil.copyfileobj(blurred_artwork, f)
+    for episode in episodes:
+        for part in episode.iterParts():
+            episode_filepath = part.file
+            episode_folder = os.path.dirname(episode_filepath)
+            episode_filename = os.path.splitext(os.path.basename(episode_filepath))[0]
             
-            # Refresh metadata for the TV show
-            plex = PlexServer(PLEX_URL, PLEX_TOKEN)
-            plex.fetchItem(opts.rating_key).show().refresh()
+            if opts.remove:
+                # Find image files with the same name as the episode
+                for filename in os.listdir(episode_folder):
+                    if filename.startswith(episode_filename) and filename.endswith(('.jpg', '.png')):
+                        # Delete the episode artwork image file
+                        os.remove(os.path.join(episode_folder, filename))
+
+            elif opts.image:
+                # File path to episode artwork using the same episode file name
+                episode_artwork = os.path.splitext(episode_filepath)[0] + os.path.splitext(opts.image)[1]
+                # Copy the image to the episode artwork
+                shutil.copy2(opts.image, episode_artwork)
+        
+            elif opts.blur:
+                # File path to episode artwork using the same episode file name
+                episode_artwork = os.path.splitext(episode_filepath)[0] + '.png'
+                # Get the blurred artwork from Tautulli
+                blurred_artwork = get_blurred_image(episode.ratingKey, opts.blur)
+                if blurred_artwork:
+                    # Copy the image to the episode artwork
+                    with open(episode_artwork, 'wb') as f:
+                        shutil.copyfileobj(blurred_artwork, f)
+
+        # Refresh metadata for the episode
+        episode.refresh()


### PR DESCRIPTION
Update `hide_episode_spoilers.py` to apply spoiler image to entire shows or seasons. Removes the `--file` argument requirement.