### PR TITLE
Remove  Tautulli dependency for hide_episode_spoilers

### DIFF
--- a/utility/hide_episode_spoilers.py
+++ b/utility/hide_episode_spoilers.py
@@ -40,8 +40,7 @@ PLEX_URL = os.getenv('PLEX_URL', PLEX_URL)
 PLEX_TOKEN = os.getenv('PLEX_TOKEN', PLEX_TOKEN)
 
 
-def modify_episode_artwork(rating_key, image=None, blur=None, summary_prefix=None, remove=False):
-    plex = PlexServer(PLEX_URL, PLEX_TOKEN)
+def modify_episode_artwork(plex, rating_key, image=None, blur=None, summary_prefix=None, remove=False):
     item = plex.fetchItem(rating_key)
 
     if item.type == 'show':
@@ -116,4 +115,5 @@ if __name__ == "__main__":
     parser.add_argument('--remove', action='store_true')
     opts = parser.parse_args()
 
-    modify_episode_artwork(**vars(opts))
+    plex = PlexServer(PLEX_URL, PLEX_TOKEN)
+    modify_episode_artwork(plex, **vars(opts))


### PR DESCRIPTION
Retrieve the blurred episode artwork directly from the Plex server to remove the Tautulli dependency. Requries [PlexAPI 4.8.0](https://github.com/pkkid/python-plexapi/releases/tag/4.8.0) with the updated `transcodeImage` method (https://github.com/pkkid/python-plexapi/pull/845).

The `modify_episode_artwork` function can also be imported into another script to loop across a library.

Example:
```py
from plexapi.server import PlexServer
from JBOPS.utility.hide_episode_spoilers import modify_episode_artwork

plex = PlexServer('http://127.0.0.1:32400', token='XXXXXXXXXXXXXXXXXXXX')
for tvshow in plex.library.section('TV Shows').all():
    modify_episode_artwork(plex, tvshow.ratingKey, blur=25)
```