### PR TITLE
find_unwatched.py - Ensure library media info is refreshed with latest data

### DIFF
--- a/utility/find_unwatched.py
+++ b/utility/find_unwatched.py
@@ -97,7 +97,8 @@ def get_library_media_info(section_id):
     payload = {'apikey': TAUTULLI_APIKEY,
                'section_id': section_id,
                'cmd': 'get_library_media_info',
-               'length': 10000}
+               'length': 10000,
+               'refresh': True}
 
     try:
         r = requests.get(TAUTULLI_URL.rstrip('/') + '/api/v2', params=payload)


### PR DESCRIPTION
Ran into an issue where the my Tautulli library media info was out of data. This caused `get_library_media_info()` to only return a small portion of the library it was querying. 

Adding refresh param to payload resolved this for me. 