### PR TITLE
 Added additional new line in the summary edit to fully hide spoilers

### DIFF
--- a/utility/hide_episode_spoilers.py
+++ b/utility/hide_episode_spoilers.py
@@ -114,7 +114,7 @@ def modify_episode_artwork(plex, rating_key, image=None, blur=None, summary_pref
 
             if summary_prefix and not episode.summary.startswith(summary_prefix):
                 # Use a zero-width space (\u200b) for blank lines
-                episode.editSummary(summary_prefix + '\n\u200b\n' + episode.summary)
+                episode.editSummary(summary_prefix + '\n\u200b\n\u200b\n' + episode.summary)
 
         # Refresh metadata for the episode
         episode.refresh()


### PR DESCRIPTION
Added additional new line in the summary edit code section to fully hide spoilers in hide_episode_spoilers.py, since the first line of the summary is still shown in the TV app.

Fixes #397 