### PR TITLE
Add incremental filename support to poster pull utility

### DIFF
--- a/utility/plex_api_poster_pull.py
+++ b/utility/plex_api_poster_pull.py
@@ -69,9 +69,12 @@ for library in library_name:
             image_path = u'{}/{}.jpg'.format(movie_path, name)
         elif child.type == 'show':
             image_path = u'{}/{}.jpg'.format(show_path, name)
-        # Check if file already exists
-        if os.path.isfile(image_path):
-            print("ERROR, %s already exist" % image_path)
-        else:
-            # Save to directory
-            urllib.request.urlretrieve(thumb_url, image_path)
+
+        # If the poster file to be written already exists, append an incrementing number to the filename
+        increment = 0
+        while os.path.isfile(image_path):
+            increment += 1
+            image_path = u'{}/{}_{}.jpg'.format(os.path.dirname(image_path), name, increment)
+
+        # Save to directory
+        urllib.request.urlretrieve(thumb_url, image_path)


### PR DESCRIPTION
Adds feature request in issue #398 

## Description

Previously, when `plex_api_poster_pull.py` pulled posters from Plex metada, it skipped writing any files that had duplicate filenames.

Now, when a duplicate filename is encountered, an incrementing number is appended to the end of the filename, and the poster file is written to disk.