### PR TITLE
Updates example documentation to use correct argument name in merge_multiepisodes script

### DIFF
--- a/utility/merge_multiepisodes.py
+++ b/utility/merge_multiepisodes.py
@@ -28,7 +28,7 @@ Usage:
         python merge_multiepisodes.py --library "TV Shows" --show "SpongeBob SquarePants" --renumber
 
     * With renumbering episodes and composite thumb:
-        python merge_multiepisodes.py --library "TV Shows" --show "SpongeBob SquarePants" --renumber --composite-thumb
+        python merge_multiepisodes.py --library "TV Shows" --show "SpongeBob SquarePants" --renumber --composite_thumb
 '''
 
 import argparse


### PR DESCRIPTION
Renames `--composite-thumb` to `--composite_thumb` in example documentation