### PR TITLE
Changed datetime.utcnow() to datetime.now(UTC) due to deprecation

### DIFF
--- a/killstream/kill_stream.py
+++ b/killstream/kill_stream.py
@@ -56,7 +56,7 @@ import sys
 import json
 import time
 import argparse
-from datetime import datetime
+from datetime import UTC, datetime
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.exceptions import RequestException
@@ -91,7 +91,7 @@ TAUTULLI_ICON = 'https://github.com/Tautulli/Tautulli/raw/master/data/interfaces
 
 def utc_now_iso():
     """Get current time in ISO format"""
-    utcnow = datetime.utcnow()
+    utcnow = datetime.now(UTC)
 
     return utcnow.isoformat()
 

--- a/reporting/weekly_stats_reporting.py
+++ b/reporting/weekly_stats_reporting.py
@@ -16,7 +16,7 @@ from __future__ import unicode_literals
 from builtins import range
 from builtins import object
 from plexapi.server import CONFIG
-from datetime import datetime, timedelta, date
+from datetime import UTC, datetime, timedelta, timezone, date
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.exceptions import RequestException
@@ -117,7 +117,7 @@ BODY_TEXT = """\
 
 def utc_now_iso():
     """Get current time in ISO format"""
-    utcnow = datetime.utcnow()
+    utcnow = datetime.now(UTC)
 
     return utcnow.isoformat()
 
@@ -467,8 +467,8 @@ if __name__ == '__main__':
     TODAY = int(time.time())
     DAYS = opts.days
     DAYS_AGO = int(TODAY - DAYS * 24 * 60 * 60)
-    START_DATE = (datetime.utcfromtimestamp(DAYS_AGO).strftime("%Y-%m-%d"))  # DAYS_AGO as YYYY-MM-DD
-    END_DATE = (datetime.utcfromtimestamp(TODAY).strftime("%Y-%m-%d"))  # TODAY as YYYY-MM-DD
+    START_DATE = (datetime.fromtimestamp(DAYS_AGO, UTC).strftime("%Y-%m-%d"))  # DAYS_AGO as YYYY-MM-DD
+    END_DATE = (datetime.fromtimestamp(TODAY, UTC).strftime("%Y-%m-%d"))  # TODAY as YYYY-MM-DD
 
     start_date = date(date_split(START_DATE)[0], date_split(START_DATE)[1], date_split(START_DATE)[2])
     end_date = date(date_split(END_DATE)[0], date_split(END_DATE)[1], date_split(END_DATE)[2])

--- a/utility/media_manager.py
+++ b/utility/media_manager.py
@@ -591,12 +591,12 @@ def action_show(items, selector, date, users=None):
         try:
             if selector == 'watched':
                 item = users[0].watch[item]
-            added_at = datetime.datetime.utcfromtimestamp(float(item.added_at)).strftime("%Y-%m-%d")
+            added_at = datetime.datetime.fromtimestamp(float(item.added_at), datetime.UTC).strftime("%Y-%m-%d")
             size = int(item.file_size) if item.file_size else 0
             sizes.append(size)
         
             if selector == 'lastPlayed':
-                last_played = datetime.datetime.utcfromtimestamp(float(item.last_played)).strftime("%Y-%m-%d")
+                last_played = datetime.datetime.fromtimestamp(float(item.last_played)datetime.UTC).strftime("%Y-%m-%d")
                 print(u"\t{} added {} and last played {}\tSize: {}\n\t\tFile: {}".format(
                     item.title, added_at, last_played, sizeof_fmt(size), item.file))
 
@@ -697,7 +697,7 @@ if __name__ == '__main__':
         date = time.mktime(time.strptime(opts.date, "%Y-%m-%d"))
     
     if date:
-        days = (datetime.datetime.utcnow() - datetime.datetime.fromtimestamp(date))
+        days = (datetime.datetime.now(datetime.UTC) - datetime.datetime.fromtimestamp(date))
         date_format = time.strftime("%Y-%m-%d", time.localtime(date))
         date_format = '{} ({} days)'.format(date_format, days.days)
     # Create a Tautulli instance


### PR DESCRIPTION
This was causing a deprecation warning so I've removed all non timezone-aware objects.

DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).utcnow = datetime.utcnow() 