### PR TITLE
Correctly read watched episodes

### DIFF
--- a/utility/sync_watch_status.py
+++ b/utility/sync_watch_status.py
@@ -415,7 +415,7 @@ def batching_watched(section, libtype):
     
         if libtype == 'show':
             search_watched = section.search(libtype='episode', container_start=start, container_size=count,
-                                         **{'show.unwatchedLeaves': False})
+                                         **{'episode.unwatched':False})
         else:
             search_watched = section.search(unwatched=False, container_start=start, container_size=count)
         if all([search_watched]):


### PR DESCRIPTION
Script works well for Movies but it couldn't find any watched episodes (from TV Shows). I checked what filter is used in web browser and 'episode.unwatched' is used there.

Plex Server version: 1.41.3.9314
PlexAPI version: 4.16.1